### PR TITLE
trigger the capistrano checklist on Gemfile updates

### DIFF
--- a/lib/deploy_complexity/checklists.rb
+++ b/lib/deploy_complexity/checklists.rb
@@ -73,6 +73,7 @@ The process for testing capistrano is to deploy the capistrano changes branch to
     def relevant_for?(files)
       files.any? do |file|
         file == "Capfile" \
+          || file == "Gemfile" \
           || file.start_with?("lib/capistrano/") \
           || file.start_with?("lib/deploy/") \
           || file.start_with?("config/deploy") \


### PR DESCRIPTION
Snipping parts of @dgtized's thoughts from the original private PR:

> The most common reason for testing Cap changes is I believe from Gem updates. [...] for now let's just include it on any Gemfile updates. That would actually catch some other cases, ie if resque updates it's somewhat recommended to test jenkins and opsworks deploy.