### PR TITLE
Update instructions to bring up new instance

### DIFF
--- a/lib/deploy_complexity/checklists.rb
+++ b/lib/deploy_complexity/checklists.rb
@@ -105,7 +105,7 @@ The process for testing capistrano is to deploy the capistrano changes branch to
       "
 - [ ] Change the source code branch for staging to the branch being tested in the opsworks UI
 - [ ] Rebase your code over `origin/staging` to prevent a successful deploy of your changes from making staging run possibly outdated code
-- [ ] Create a brand new instance in the layer ([see instructions](https://github.com/NoRedInk/wiki/blob/master/ops-playbook/ops-scripts.md#synchronize_stackrb.))
+- [ ] Create a brand new instance in the layer ([see instructions](https://github.com/NoRedInk/wiki/blob/1f618042ed1d6b7c7297ec2672ae568e57944fde/ops-playbook/ops-plays.md#using-opsworks-to-bring-up-an-additional-time-based-instance))
 - [ ] Turn it on
 - [ ] Verify that the instances passes setup to online and doesn't fail
       ".strip

--- a/lib/deploy_complexity/checklists.rb
+++ b/lib/deploy_complexity/checklists.rb
@@ -105,8 +105,7 @@ The process for testing capistrano is to deploy the capistrano changes branch to
       "
 - [ ] Change the source code branch for staging to the branch being tested in the opsworks UI
 - [ ] Rebase your code over `origin/staging` to prevent a successful deploy of your changes from making staging run possibly outdated code
-- [ ] Create a brand new instance in the layer ([see instructions](https://github.com/NoRedInk/wiki/blob/1f618042ed1d6b7c7297ec2672ae568e57944fde/ops-playbook/ops-plays.md#using-opsworks-to-bring-up-an-additional-time-based-instance))
-- [ ] Turn it on
+- [ ] Turn on an additional time-based instance in the layer ([see instructions](https://github.com/NoRedInk/wiki/blob/1f618042ed1d6b7c7297ec2672ae568e57944fde/ops-playbook/ops-plays.md#using-opsworks-to-bring-up-an-additional-time-based-instance))
 - [ ] Verify that the instances passes setup to online and doesn't fail
       ".strip
     end


### PR DESCRIPTION
Sister to:
* https://github.com/NoRedInk/NoRedInk/pull/22622
* https://github.com/NoRedInk/wiki/pull/1206

We're removing synchronize-stacks now that we're using Terraform. Luckily there were already instructions on how to bring up temporary instances through the UI.