### PR TITLE
Add `--subdir` option for filtering PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ as well direct links to the github diff for the deploy, links to migrations, and
 individual PRs.
 
 ## Examples
+
 ```
 $ deploy-complexity.rb
 Displays code that would be promoted if staging deployed to production, or master
@@ -21,6 +22,8 @@ $ deploy-complexity.rb -d 3
 Displays the last 3 deploys on production
 $ deploy-complexity.rb -b staging -d
 Show changes from every single staging deploy
+$ deploy-complexity.rb --pattern '^subdir/'
+Show only PRs that make modifications to files in the subdir/ directory.
 ```
 
 ### For Testing
@@ -42,20 +45,20 @@ module Checklists
     def human_name
       "Blarg!"
     end
-    
+
     def checklist
     '- [ ] Removed extraneous blargh'.strip
     end
-    
+
     def relevant_for(files)
-      files.select do |file| 
+      files.select do |file|
         file.ends_with(".rb") && IO.read(file) =~ /blargh/
       end
     end
   end
 
   module_function
-  
+
   # List of checklists to run
   def checklists
     [BlarghDetector].freeze

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ deploy-complexity.rb -d 3
 Displays the last 3 deploys on production
 $ deploy-complexity.rb -b staging -d
 Show changes from every single staging deploy
-$ deploy-complexity.rb --pattern '^subdir/'
+$ deploy-complexity.rb --subdir 'subdir/'
 Show only PRs that make modifications to files in the subdir/ directory.
 ```
 

--- a/exe/deploy-complexity.rb
+++ b/exe/deploy-complexity.rb
@@ -27,6 +27,10 @@ optparse = OptionParser.new do |opts| # rubocop:disable Metrics/BlockLength
     last_n_deploys = e.to_i
     last_n_deploys = nil if last_n_deploys.zero?
   end
+  opts.on("-p", "--pattern PATTERN", String,
+          "Only count PRs that make changes to files matching this pattern") do |pattern|
+    options[:pattern] = pattern
+  end
   opts.on("--dirstat",
           "Statistics on directory changes") { options[:dirstat] = true }
   opts.on("--stat",

--- a/exe/deploy-complexity.rb
+++ b/exe/deploy-complexity.rb
@@ -27,7 +27,7 @@ optparse = OptionParser.new do |opts| # rubocop:disable Metrics/BlockLength
     last_n_deploys = e.to_i
     last_n_deploys = nil if last_n_deploys.zero?
   end
-  opts.on("-p", "--subdir PATTERN", String,
+  opts.on("-s", "--subdir PATTERN", String,
           "Only count PRs that make changes to files in this directory") do |subdir|
     options[:subdir] = subdir
   end

--- a/exe/deploy-complexity.rb
+++ b/exe/deploy-complexity.rb
@@ -27,9 +27,9 @@ optparse = OptionParser.new do |opts| # rubocop:disable Metrics/BlockLength
     last_n_deploys = e.to_i
     last_n_deploys = nil if last_n_deploys.zero?
   end
-  opts.on("-p", "--pattern PATTERN", String,
-          "Only count PRs that make changes to files matching this pattern") do |pattern|
-    options[:pattern] = pattern
+  opts.on("-p", "--subdir PATTERN", String,
+          "Only count PRs that make changes to files in this directory") do |subdir|
+    options[:subdir] = subdir
   end
   opts.on("--dirstat",
           "Statistics on directory changes") { options[:dirstat] = true }

--- a/lib/deploy_complexity/changed_elm_packages.rb
+++ b/lib/deploy_complexity/changed_elm_packages.rb
@@ -9,6 +9,10 @@ module DeployComplexity
     private
 
     def parse_dependencies(file)
+      # When a elm.json file gets created or deleted we might be comparing
+      # against a non-existing file. In that case we're passed an empty string.
+      return {} if file.empty?
+
       json = JSON.parse(file)
       dependencies = json.fetch("dependencies")
       test_dependencies = json.fetch("test-dependencies")

--- a/lib/deploy_complexity/deploy.rb
+++ b/lib/deploy_complexity/deploy.rb
@@ -190,7 +190,7 @@ module DeployComplexity
     end
 
     def gitroot
-      `realpath --relative-to . $(git rev-parse --show-toplevel)`.strip()
+      `realpath --relative-to . $(git rev-parse --show-toplevel)`.strip
     end
   end
 end

--- a/lib/deploy_complexity/deploy.rb
+++ b/lib/deploy_complexity/deploy.rb
@@ -176,17 +176,17 @@ module DeployComplexity
     end
 
     def shortstat
-      `git diff --shortstat --summary #{range} #{subdir}`.split(/\n/)
+      `git diff --shortstat --summary #{range} -- #{subdir}`.split(/\n/)
     end
 
     def dirstat
-      `git diff --dirstat=lines,cumulative #{range} #{subdir}` if @options[:dirstat]
+      `git diff --dirstat=lines,cumulative #{range} -- #{subdir}` if @options[:dirstat]
     end
 
     def stat
       # TODO: investigate summarizing language / spec content based on file suffix,
       # and possibly per PR, or classify frontend, backend, spec changes
-      `git diff --stat #{range} #{subdir}` if @options[:stat]
+      `git diff --stat #{range} -- #{subdir}` if @options[:stat]
     end
   end
 end

--- a/lib/deploy_complexity/deploy.rb
+++ b/lib/deploy_complexity/deploy.rb
@@ -37,7 +37,7 @@ module DeployComplexity
       time_delta = time_between_deploys(Git.safe_name(base), Git.safe_name(to))
 
       commits = `git log --oneline #{range}`.split(/\n/)
-      merges = get_merges(commits, options)
+      merges = get_merges(commits)
 
       shortstat = `git diff --shortstat --summary #{range}`.split(/\n/)
       names_only = `git diff --name-only #{range}`
@@ -156,17 +156,20 @@ module DeployComplexity
       end.compact
     end
 
-    def get_merges(commits, options)
+    def get_merges(commits)
       merges = commits.grep(/Merges|\#\d+/)
-      pattern = Regexp.new(options[:pattern]) if options[:pattern]
-      merges = merges.select { |m| makes_changes_to(m, pattern) } if pattern
+      merges = merges.select { |m| makes_changes_to(m) }
       merges
     end
 
-    def makes_changes_to(merge, pattern)
+    def makes_changes_to(merge)
       commithash = merge.split(' ')[0]
       commits = `git log -m -1 --name-only --first-parent --pretty="format:" #{commithash}`.split(/\n/)
       commits.any? { |commit| pattern =~ commit }
+    end
+
+    def pattern
+      @pattern ||= options[:pattern] ? Regexp.new(@options[:pattern]) : /.*/
     end
   end
 end

--- a/lib/deploy_complexity/deploy.rb
+++ b/lib/deploy_complexity/deploy.rb
@@ -37,7 +37,7 @@ module DeployComplexity
       time_delta = time_between_deploys(Git.safe_name(base), Git.safe_name(to))
 
       commits = `git log --oneline #{range}`.split(/\n/)
-      merges = get_merges(commits, options[:pattern])
+      merges = get_merges(commits, options)
 
       shortstat = `git diff --shortstat --summary #{range}`.split(/\n/)
       names_only = `git diff --name-only #{range}`
@@ -156,9 +156,9 @@ module DeployComplexity
       end.compact
     end
 
-    def get_merges(commits, pattern)
+    def get_merges(commits, options)
       merges = commits.grep(/Merges|\#\d+/)
-      pattern = Regexp.new(pattern) if pattern
+      pattern = Regexp.new(options[:pattern]) if options[:pattern]
       merges = merges.select { |m| makes_changes_to(m, pattern) } if pattern
       merges
     end

--- a/lib/deploy_complexity/deploy.rb
+++ b/lib/deploy_complexity/deploy.rb
@@ -168,7 +168,7 @@ module DeployComplexity
     end
 
     def subdir
-      @options[:subdir] || ""
+      @options[:subdir] ? File.join(gitroot, @options[:subdir]) : ""
     end
 
     def range
@@ -187,6 +187,10 @@ module DeployComplexity
       # TODO: investigate summarizing language / spec content based on file suffix,
       # and possibly per PR, or classify frontend, backend, spec changes
       `git diff --stat #{range} -- #{subdir}` if @options[:stat]
+    end
+
+    def gitroot
+      `realpath --relative-to . $(git rev-parse --show-toplevel)`.strip()
     end
   end
 end

--- a/lib/deploy_complexity/deploy.rb
+++ b/lib/deploy_complexity/deploy.rb
@@ -40,8 +40,7 @@ module DeployComplexity
       merges = get_merges(commits)
 
       shortstat = `git diff --shortstat --summary #{range}`.split(/\n/)
-      names_only = `git diff --name-only #{range}`
-      changed_files = DeployComplexity::ChangedFiles.new(names_only)
+      changed_files = get_changed_files(range)
 
       dirstat = `git diff --dirstat=lines,cumulative #{range}` if dirstat
       # TODO: investigate summarizing language / spec content based on file suffix,
@@ -160,6 +159,12 @@ module DeployComplexity
       merges = commits.grep(/Merges|\#\d+/)
       merges = merges.select { |m| makes_changes_to(m) }
       merges
+    end
+
+    def get_changed_files(range)
+      files = `git diff --name-only #{range}`
+      filtered = files.split(/\n/).select { |f| pattern =~ f }.join('\n')
+      changed_files = DeployComplexity::ChangedFiles.new(filtered)
     end
 
     def makes_changes_to(merge)

--- a/lib/deploy_complexity/deploy.rb
+++ b/lib/deploy_complexity/deploy.rb
@@ -28,7 +28,6 @@ module DeployComplexity
       github = Github.new(options[:gh_url])
       dirstat = options[:dirstat]
       stat = options[:stat]
-      pattern = options[:pattern]
 
       range = "#{base}...#{to}"
 
@@ -38,9 +37,7 @@ module DeployComplexity
       time_delta = time_between_deploys(Git.safe_name(base), Git.safe_name(to))
 
       commits = `git log --oneline #{range}`.split(/\n/)
-      merges = commits.grep(/Merges|\#\d+/)
-      pattern = Regexp.new(pattern) if pattern
-      merges = merges.select { |m| makes_changes_to(m, pattern) } if pattern
+      merges = get_merges(commits, options[:pattern])
 
       shortstat = `git diff --shortstat --summary #{range}`.split(/\n/)
       names_only = `git diff --name-only #{range}`
@@ -157,6 +154,13 @@ module DeployComplexity
           }
         end
       end.compact
+    end
+
+    def get_merges(commits, pattern)
+      merges = commits.grep(/Merges|\#\d+/)
+      pattern = Regexp.new(pattern) if pattern
+      merges = merges.select { |m| makes_changes_to(m, pattern) } if pattern
+      merges
     end
 
     def makes_changes_to(merge, pattern)

--- a/lib/deploy_complexity/deploy.rb
+++ b/lib/deploy_complexity/deploy.rb
@@ -164,7 +164,7 @@ module DeployComplexity
     def get_changed_files(range)
       files = `git diff --name-only #{range}`
       filtered = files.split(/\n/).select { |f| pattern =~ f }.join('\n')
-      changed_files = DeployComplexity::ChangedFiles.new(filtered)
+      DeployComplexity::ChangedFiles.new(filtered)
     end
 
     def makes_changes_to(merge)
@@ -174,7 +174,7 @@ module DeployComplexity
     end
 
     def pattern
-      @pattern ||= options[:pattern] ? Regexp.new(@options[:pattern]) : /.*/
+      @pattern ||= options[:subdir] ? Regexp.new("^" + @options[:subdir]) : /.*/
     end
   end
 end

--- a/lib/deploy_complexity/deploy.rb
+++ b/lib/deploy_complexity/deploy.rb
@@ -39,13 +39,13 @@ module DeployComplexity
       commits = `git log --oneline #{range}`.split(/\n/)
       merges = get_merges(commits)
 
-      shortstat = `git diff --shortstat --summary #{range}`.split(/\n/)
+      shortstat = `git diff --shortstat --summary #{range} #{subdir}`.split(/\n/)
       changed_files = get_changed_files(range)
 
-      dirstat = `git diff --dirstat=lines,cumulative #{range}` if dirstat
+      dirstat = `git diff --dirstat=lines,cumulative #{range} #{subdir}` if dirstat
       # TODO: investigate summarizing language / spec content based on file suffix,
       # and possibly per PR, or classify frontend, backend, spec changes
-      stat = `git diff --stat #{range}` if stat
+      stat = `git diff --stat #{range} #{subdir}` if stat
 
       # TODO: scan for changes to app/jobs and report changes to params
       formatter_attributes = {
@@ -175,6 +175,10 @@ module DeployComplexity
 
     def pattern
       @pattern ||= options[:subdir] ? Regexp.new("^" + @options[:subdir]) : /.*/
+    end
+
+    def subdir
+      @options[:subdir] || ""
     end
   end
 end

--- a/lib/deploy_complexity/revision_comparator.rb
+++ b/lib/deploy_complexity/revision_comparator.rb
@@ -23,7 +23,11 @@ module DeployComplexity
     private
 
     def source(revision, file)
-      `git show #{revision}:#{file}`
+      # A file may legitimately not exist, if it was created or deleted between
+      # the old and new revisions. `git show` will log to stderr in that case,
+      # introducing unhelpful noise in the complexity report. To prevent this we
+      # redirect stderr to `/dev/null`.
+      `git show #{revision}:#{file} 2>/dev/null`
     end
 
     def changes


### PR DESCRIPTION
The option will only display PRs that modified files in a particular subdirectory.

For example, to filter PRs down to only those that modify files in the `subproject/` directory:

```
deploy-complexity.rb --subdir 'subproject/'
```