### PR TITLE
Prepare release 0.12.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    deploy-complexity (0.11.0)
+    deploy-complexity (0.12.0)
       octokit (~> 4.0)
       slack-notifier (~> 2.3.2)
       values (~> 1.8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.11)
+  bundler (~> 2.1)
   deploy-complexity!
   pry
   pry-doc

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,15 @@
+# Releasing a new version
+
+This gem is primarily consumed internally at NoRedInk and is not published
+to rubygems.org.
+
+1. Create a branch named like `release-x.y.z`.
+1. Update the version in `lib/deploy_complexity/version.rb`.
+1. Run `bundle install`. This will update `Gemfile.lock`.
+1. Commit the `version.rb` and `Gemfile.lock` changes with a message like "Prepare release vX.Y.Z".
+1. Push the branch and open a PR. Optionally, ask for a review.
+1. Once CI is green, merge the PR.
+1. Checkout master and run `gem_push=no rake release`. This will tag the current revision and push it to GitHub.
+1. Go to [GitHub releases page][releases] and find the draft release. Set the release title to the version string, write a short description of the changes, and publish it.
+
+[releases]: https://github.com/NoRedInk/deploy-complexity/releases

--- a/deploy-complexity.gemspec
+++ b/deploy-complexity.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 13.0"
 
   spec.add_dependency "octokit", "~> 4.0"

--- a/lib/deploy_complexity/version.rb
+++ b/lib/deploy_complexity/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeployComplexity
-  VERSION = "0.11.0"
+  VERSION = "0.12.0"
 end


### PR DESCRIPTION
Bugfixes
- #26 Support branch names with slashes

Backwards incompatible changes
- Minimum required Ruby version is now specified as 2.5

---

This PR also adds `RELEASING.md`: it's based entirely on my imagination as I haven't released anything in this repo before. I'd appreciate a good look here.