### PR TITLE
Fix release steps and shell.nix

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,7 +9,7 @@ to rubygems.org.
 1. Commit the `version.rb` and `Gemfile.lock` changes with a message like "Prepare release vX.Y.Z".
 1. Push the branch and open a PR. Optionally, ask for a review.
 1. Once CI is green, merge the PR.
-1. Checkout master and run `gem_push=no rake release`. This will tag the current revision and push it to GitHub.
+1. Checkout master, pull, and run `gem_push=no bundle exec rake release`. This will tag the current revision and push it to GitHub.
 1. Go to [GitHub releases page][releases] and find the draft release. Set the release title to the version string, write a short description of the changes, and publish it.
 
 [releases]: https://github.com/NoRedInk/deploy-complexity/releases

--- a/shell.nix
+++ b/shell.nix
@@ -17,11 +17,13 @@ let
 
   rubyVersion = lib.fileContents ./.ruby-version;
   bundlerVersion = lib.fileContents ./.bundler-version;
+
+  ruby = ruby_2_5;
 in stdenv.mkDerivation {
   name = "deploy-complexity";
   buildInputs = [
     git
-    (expectVersion rubyVersion ruby_2_5)
-    (expectVersion bundlerVersion (bundler.override { ruby = ruby_2_5; }))
+    (expectVersion rubyVersion ruby)
+    (expectVersion bundlerVersion (bundler.override { inherit ruby; }))
   ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,16 +1,15 @@
 with import (builtins.fetchTarball rec {
   # grab a hash from here: https://nixos.org/channels/
   name = "nixpkgs-darwin-20.03pre214403.c23427de0d5";
-  url = "https://github.com/nixos/nixpkgs/archive/c23427de0d501009b9c6d77ff8dda3763c6eb1b4.tar.gz";
+  url =
+    "https://github.com/nixos/nixpkgs/archive/c23427de0d501009b9c6d77ff8dda3763c6eb1b4.tar.gz";
   # Hash obtained using `nix-prefetch-url --unpack <url>`
   sha256 = "0fgv4pyzn39y8ibskn37x9cabmg6gflisigr5l45bkplm06bss91";
-}) {};
+}) { };
 let
   expectVersion = version: pkg:
-    let
-      actual = lib.getVersion pkg;
-    in
-    assert (lib.assertMsg (builtins.toString actual == version) ''
+    let actual = lib.getVersion pkg;
+    in assert (lib.assertMsg (builtins.toString actual == version) ''
       Expecting version of ${pkg.name} to be ${version} but got ${actual};
       adjust the expected version or fetch/build the desired version of the package.
     '');
@@ -18,8 +17,7 @@ let
 
   rubyVersion = lib.fileContents ./.ruby-version;
   bundlerVersion = lib.fileContents ./.bundler-version;
-in
-stdenv.mkDerivation {
+in stdenv.mkDerivation {
   name = "deploy-complexity";
   buildInputs = [
     git

--- a/shell.nix
+++ b/shell.nix
@@ -24,6 +24,6 @@ stdenv.mkDerivation {
   buildInputs = [
     git
     (expectVersion rubyVersion ruby_2_5)
-    (expectVersion bundlerVersion bundler)
+    (expectVersion bundlerVersion (bundler.override { ruby = ruby_2_5; }))
   ];
 }


### PR DESCRIPTION
Minor fixes I needed before being able to run `rake release`.

Trivial, merging.