### PR TITLE
Handle the case of a PR without a body at all (nil)

### DIFF
--- a/lib/deploy_complexity/pull_request.rb
+++ b/lib/deploy_complexity/pull_request.rb
@@ -38,7 +38,7 @@ class PullRequest
     return {} if pr.nil?
 
     new_checklists =
-      checklists.reject { |checklist, _| pr.body.include? checklist.id }
+      checklists.reject { |checklist, _| pr.body&.include? checklist.id }
 
     unless checklists.empty?
       new_body = body_with_checklist(new_checklists)
@@ -92,7 +92,7 @@ class PullRequest
   end
 
   def body_with_checklist(checklists)
-    body = pr.body.clone
+    body = pr.body ? pr.body.clone : ""
 
     checklists.each do |checklist, _|
       body += checklist.for_pr_body

--- a/spec/lib/deploy_complexity/pull_request_spec.rb
+++ b/spec/lib/deploy_complexity/pull_request_spec.rb
@@ -61,6 +61,14 @@ describe PullRequest do
   describe 'update_with_checklists' do
     let(:checklists) { { checklist => ["file"] } }
 
+    context "when the checklist is nil" do
+      let(:body) { nil }
+
+      it "should add the checklist" do
+        expect(subject.update_with_checklists(checklists, false)).to include(checklist)
+      end
+    end
+
     context "when the checklist isn't present" do
       let(:body) { "" }
 


### PR DESCRIPTION
We had a case where a PR was sent without a body at all. Then deploy-complexity failed because apparently that comes as `nil` instead of an empty string. This PR handles this case.